### PR TITLE
Skip a test in t/04-window.t which fails with "No such atom (WM_PROTOCOLS)"

### DIFF
--- a/t/04-window.t
+++ b/t/04-window.t
@@ -23,6 +23,11 @@ SKIP: {
 
     isa_ok($root, 'X11::XCB::Window');
 
+SKIP: {
+    my $wm_protocols_atom = $x->atom(name => 'WM_PROTOCOLS');
+    skip "Connection doesn't support atom WM_PROTOCOLS, maybe related to Xvfb.", 1
+        unless $wm_protocols_atom->exists;
+
     my $rect = $root->rect;
 
     ok('rect of the root window could be retrieved');
@@ -40,6 +45,8 @@ SKIP: {
     sleep 1;
     $window->delete_hint('urgency');
     sleep 1;
+} # end SKIP WM_PROTOCOLS
+
 }
 
 diag( "Testing X11::XCB, Perl $], $^X" );


### PR DESCRIPTION

In Debian we are currently applying the following patch to X11-XCB.
We thought you might be interested in it too.

    Description: Skip a test in t/04-window.t which fails with "No such atom (WM_PROTOCOLS)"
     at least when run under Xvfb. Check if a WM_PROTOCOLS atom works before using it.
     .
     Seen in a Debian unstable chroot, and apparently also on Gentoo:
     https://archives.gentoo.org/gentoo-commits/1751655611.b2b56d08c5dc1c6fc599d5a785447b99eaf37b64.sam@gentoo/
     where t/04-window.t is removed.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2025-08-21
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libx11-xcb-perl/raw/master/debian/patches/WM_PROTOCOLS.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
